### PR TITLE
refactor: Remove as prop from router.push

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -153,9 +153,6 @@ function Index({ product }) {
                         onClick={() =>
                           router.push(
                             program.free
-                              ? '/program/[category]/sample/[id]'
-                              : '/program/[category]/[date]',
-                            program.free
                               ? `/program/${program.category.toLowerCase()}/sample/${
                                   program.id
                                 }`


### PR DESCRIPTION
No longer needed for dynamic routes as of `next@9.5.3`