### PR TITLE
refactor: `react-hook-form` update

### DIFF
--- a/components/form/input.js
+++ b/components/form/input.js
@@ -32,11 +32,10 @@ function FormInput({
                 'cursor-not-allowed opacity-50': disabled
               }
             )}
-            name={field}
             id={field}
             type={type}
             disabled={disabled}
-            ref={register}
+            {...register(field)}
             {...props}
           />
         </div>

--- a/components/form/input.js
+++ b/components/form/input.js
@@ -11,7 +11,10 @@ function FormInput({
   type = 'text',
   ...props
 }) {
-  const { errors, register } = useFormContext()
+  const {
+    formState: { errors },
+    register
+  } = useFormContext()
 
   const hasError = errors[field]
 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@headlessui/react": "1.4.2",
     "@heroicons/react": "1.0.5",
-    "@hookform/resolvers": "1.3.7",
+    "@hookform/resolvers": "2.8.3",
     "@stripe/react-stripe-js": "1.6.0",
     "@stripe/stripe-js": "1.21.1",
     "classnames": "2.3.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -692,10 +692,10 @@
   resolved "https://registry.yarnpkg.com/@heroicons/react/-/react-1.0.5.tgz#2fe4df9d33eb6ce6d5178a0f862e97b61c01e27d"
   integrity sha512-UDMyLM2KavIu2vlWfMspapw9yii7aoLwzI2Hudx4fyoPwfKfxU8r3cL8dEBXOjcLG0/oOONZzbT14M1HoNtEcg==
 
-"@hookform/resolvers@1.3.7":
-  version "1.3.7"
-  resolved "https://registry.yarnpkg.com/@hookform/resolvers/-/resolvers-1.3.7.tgz#7c164d438b788cc625e46c22885ca6edc254350b"
-  integrity sha512-gC06h1hky7gM31UO4Y7DrUQjgZyNIKA3s0/TxXbdeurwhOj07l8Zx8Pomjt93ANOKoZOU2rcHKaZtrEJx1w7tg==
+"@hookform/resolvers@2.8.3":
+  version "2.8.3"
+  resolved "https://registry.yarnpkg.com/@hookform/resolvers/-/resolvers-2.8.3.tgz#d362360f6057bcca7318ad22d49e5f0c47290e27"
+  integrity sha512-9G6/vCUNvg3O4MeAK4l749syOz/2r1DF/Pq3Njuk3sI4ObHoRyV0nxio5NrNLGC+7N1Ixu9vJ/loNhaUNXTX6A==
 
 "@mdx-js/mdx@^1.6.22":
   version "1.6.22"


### PR DESCRIPTION
Necessary updates for the `react-hook-form@7.x.x` [migration](https://react-hook-form.com/migrate-v6-to-v7/).