### PR TITLE
fix: Return `revalidate` prop for 404 routes

### DIFF
--- a/pages/program/[category]/[date].js
+++ b/pages/program/[category]/[date].js
@@ -53,7 +53,8 @@ export async function getStaticProps({ params, preview = false }) {
 
   if (!program) {
     return {
-      notFound: true
+      notFound: true,
+      revalidate: 10
     }
   }
 

--- a/pages/program/[category]/sample/[id].js
+++ b/pages/program/[category]/sample/[id].js
@@ -46,7 +46,8 @@ export async function getStaticProps({ params, preview = false }) {
 
   if (!program) {
     return {
-      notFound: true
+      notFound: true,
+      revalidate: 10
     }
   }
 


### PR DESCRIPTION
Ensures they will be revalidated if route does then exist