### PR TITLE
fix: Only add a new sheet if one does not already exist

### DIFF
--- a/lib/google-spreadsheet.ts
+++ b/lib/google-spreadsheet.ts
@@ -33,10 +33,14 @@ const addSpectatorSheetRow = async ({
       private_key: process.env.GOOGLE_PRIVATE_KEY.replace(/\\n/g, '\n')
     })
 
-    const sheet = await doc.addSheet({
-      headerValues: ['id', 'name', 'email', 'quantity'],
-      title: lineItem.description
-    })
+    await doc.loadInfo()
+
+    const sheet =
+      doc.sheetsByTitle[lineItem.description] ??
+      (await doc.addSheet({
+        headerValues: ['id', 'name', 'email', 'quantity'],
+        title: lineItem.description
+      }))
 
     const row: SpectatorSheetRowProps = {
       id: checkoutSession.id,


### PR DESCRIPTION
Check spreadsheet document for an existing sheet, otherwise create a new one. Prevents error when attempting to create duplicate sheets with same title.