### PR TITLE
feat: Upgrade Stripe API version to `2022-08-01`

### DIFF
--- a/lib/google-spreadsheet.ts
+++ b/lib/google-spreadsheet.ts
@@ -17,7 +17,7 @@ const addSpectatorSheetRow = async ({
 }): Promise<void> => {
   try {
     const stripe = new Stripe(process.env.STRIPE_SECRET_KEY, {
-      apiVersion: '2020-08-27'
+      apiVersion: '2022-08-01'
     })
 
     const {

--- a/pages/api/stripe/checkout/sessions/create.ts
+++ b/pages/api/stripe/checkout/sessions/create.ts
@@ -13,7 +13,7 @@ async function handler(
 ) {
   try {
     const stripe = new Stripe(process.env.STRIPE_SECRET_KEY, {
-      apiVersion: '2020-08-27'
+      apiVersion: '2022-08-01'
     })
 
     const findUserCustomerId = async (user) => {

--- a/pages/api/stripe/checkout/sessions/create.ts
+++ b/pages/api/stripe/checkout/sessions/create.ts
@@ -30,7 +30,6 @@ async function handler(
     const {
       adjustable_quantity = { enabled: false },
       allow_promotion_codes = true,
-      customer_creation = 'if_required',
       mode = 'subscription',
       price,
       trial_from_plan = false,
@@ -39,9 +38,7 @@ async function handler(
 
     const params: Stripe.Checkout.SessionCreateParams = {
       allow_promotion_codes,
-      ...(user
-        ? { customer: await findUserCustomerId(user) }
-        : { customer_creation }),
+      ...(user && { customer: await findUserCustomerId(user) }),
       line_items: [
         {
           adjustable_quantity,

--- a/pages/api/stripe/customer-portal/sessions/create.ts
+++ b/pages/api/stripe/customer-portal/sessions/create.ts
@@ -13,7 +13,7 @@ async function handler(
 ) {
   try {
     const stripe = new Stripe(process.env.STRIPE_SECRET_KEY, {
-      apiVersion: '2020-08-27'
+      apiVersion: '2022-08-01'
     })
 
     const { stripeId: customer }: FirebaseFirestore.DocumentData = (

--- a/pages/api/stripe/webhooks.ts
+++ b/pages/api/stripe/webhooks.ts
@@ -20,7 +20,7 @@ const verifyStripeSignature =
   ) =>
   async (req: NextApiRequest, res: NextApiResponse<{ message: any }>) => {
     const stripe = new Stripe(process.env.STRIPE_SECRET_KEY, {
-      apiVersion: '2020-08-27'
+      apiVersion: '2022-08-01'
     })
 
     const chunks = []

--- a/pages/program/index.js
+++ b/pages/program/index.js
@@ -175,7 +175,7 @@ function Index({ preview, price }) {
 
 export async function getStaticProps({ preview = false }) {
   const stripe = new Stripe(process.env.STRIPE_SECRET_KEY, {
-    apiVersion: '2020-08-27'
+    apiVersion: '2022-08-01'
   })
 
   const price = await stripe.prices.retrieve(


### PR DESCRIPTION
* Bump `apiVersion` parameter when initialising Stripe client.
* Remove (now redundant) `customer_creation` parameter from Checkout Session creation. `if_required` is now default behaviour in `mode: 'payment'` sessions.