### PR TITLE
feat: Past event safety

### DIFF
--- a/components/competition-info.js
+++ b/components/competition-info.js
@@ -2,11 +2,13 @@ import * as React from 'react'
 import Link from 'next/link'
 import cx from 'classnames'
 import { ExternalLinkIcon, PaperClipIcon } from '@heroicons/react/outline'
+import subWeeks from 'date-fns/subWeeks'
 
 import VenueMap from '@/components/venue-map'
 
 function CompetitionInfo({ competition }) {
-  const pastCompetition = new Date(competition.startDate) < new Date()
+  const pastCompetition =
+    subWeeks(new Date(competition.startDate), 2) < new Date()
 
   const information = React.useMemo(
     () => [

--- a/components/mdx/index.js
+++ b/components/mdx/index.js
@@ -1,4 +1,5 @@
 import * as React from 'react'
+import subDays from 'date-fns/subDays'
 
 import Alert from '@/components/alert'
 import Button from '@/components/button'
@@ -34,7 +35,8 @@ const competitionMdxComponents = {
       }
     }
 
-    const pastCompetition = new Date(competition.endDate) < new Date()
+    const pastCompetition =
+      subDays(new Date(competition.startDate), 1) < new Date()
 
     return (
       <Button


### PR DESCRIPTION
Prevent spectator ticket purchases for events within 24 hours of start date.